### PR TITLE
Support for p4maven scm provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
       <artifactId>maven-scm-provider-perforce</artifactId>
       <version>${version.maven-scm}</version>
     </dependency>
+    <dependency>
+      <groupId>com.perforce</groupId>
+      <artifactId>p4maven</artifactId>
+      <version>[2011,2012)</version>
+    </dependency>
 
     <!-- TFS -->
     <dependency>

--- a/src/main/java/org/sonar/plugins/scmactivity/SupportedScm.java
+++ b/src/main/java/org/sonar/plugins/scmactivity/SupportedScm.java
@@ -20,6 +20,7 @@
 
 package org.sonar.plugins.scmactivity;
 
+import com.perforce.maven.scm.provider.p4.P4ScmProvider;
 import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.accurev.AccuRevScmProvider;
 import org.apache.maven.scm.provider.bazaar.BazaarScmProvider;
@@ -42,6 +43,7 @@ public enum SupportedScm {
   CLEAR_CASE(new ClearCaseScmProvider(), null),
   ACCU_REV(new AccuRevScmProvider(), null),
   PERFORCE(new PerforceScmProvider(), null),
+  P4(new P4ScmProvider(), null),
   TFS(new TfsScmProvider(), null),
   JAZZ(new JazzScmProvider(), null),
   INTEGRITY(new IntegrityScmProvider(), null);


### PR DESCRIPTION
Hello - I work for a company that uses perforce. We've come to the end of our rope using the 'perforce' scm provider and have switched to the 'p4maven' provider. This provider is 100% java (doesn't need the p4 executable), handles authentication much better and is provided by Perforce themselves. I had to make a small tweak to the scm activity plugin to allow it to use this scm provider.

I also had to make a small change to p4maven's "blame" command implementation. The signature of the blame command looks like this:
```java
public abstract BlameScmResult executeBlameCommand( 
                                  ScmProviderRepository repo, 
                                  ScmFileSet workingDirectory,
                                  String filename ) throws ScmException;
```
But for whatever reason, the p4maven command was not correctly formulating the complete filename from the given arguments (it was just using the relative filename and ignoring the workingDirectory argument). So, without this small fix in p4maven, the blame command won't work correctly... 

But I think the scm activity plugin could work around the issue by passing the absolute path in, e.g.:
```java
public BlameScmResult blame(File file) throws ScmException {
    String fileName = isP4MavenProvider() ? file.getAbsolutePath() : file.getName();
    return scmManager.blame(getScmRepository(), new ScmFileSet(file.getParentFile()), fileName);
}
```
Or something of that sort?