### PR TITLE
NullPointerException in Blame for line with author == null

### DIFF
--- a/src/main/java/org/sonar/plugins/scmactivity/Blame.java
+++ b/src/main/java/org/sonar/plugins/scmactivity/Blame.java
@@ -60,14 +60,15 @@ public class Blame implements BatchExtension {
 
     int lineNumber = 1;
     for (BlameLine line : result.getLines()) {
-      authors.add(lineNumber, normalizeString(line.getAuthor()));
+      final String author = line.getAuthor() == null ? "" : line.getAuthor();
+      authors.add(lineNumber, normalizeString(author));
       dates.add(lineNumber, DateUtils.formatDateTime(line.getDate()));
       revisions.add(lineNumber, line.getRevision());
 
       lineNumber++;
       // SONARPLUGINS-3097 For some SCM blame is missing on last empty line
       if (lineNumber > result.getLines().size() && lineNumber == lineCount) {
-        authors.add(lineNumber, normalizeString(line.getAuthor()));
+        authors.add(lineNumber, normalizeString(author));
         dates.add(lineNumber, DateUtils.formatDateTime(line.getDate()));
         revisions.add(lineNumber, line.getRevision());
       }

--- a/src/main/java/org/sonar/plugins/scmactivity/Blame.java
+++ b/src/main/java/org/sonar/plugins/scmactivity/Blame.java
@@ -60,15 +60,14 @@ public class Blame implements BatchExtension {
 
     int lineNumber = 1;
     for (BlameLine line : result.getLines()) {
-      final String author = line.getAuthor() == null ? "" : line.getAuthor();
-      authors.add(lineNumber, normalizeString(author));
+      authors.add(lineNumber, normalizeString(line.getAuthor()));
       dates.add(lineNumber, DateUtils.formatDateTime(line.getDate()));
       revisions.add(lineNumber, line.getRevision());
 
       lineNumber++;
       // SONARPLUGINS-3097 For some SCM blame is missing on last empty line
       if (lineNumber > result.getLines().size() && lineNumber == lineCount) {
-        authors.add(lineNumber, normalizeString(author));
+        authors.add(lineNumber, normalizeString(line.getAuthor()));
         dates.add(lineNumber, DateUtils.formatDateTime(line.getDate()));
         revisions.add(lineNumber, line.getRevision());
       }
@@ -99,6 +98,9 @@ public class Blame implements BatchExtension {
   }
 
   private String normalizeString(String inputString) {
+    if (inputString == null) {
+      return "";
+    }
     String lowerCasedString = inputString.toLowerCase();
     String stringWithoutAccents = removeAccents(lowerCasedString);
     return removeNonAsciiCharacters(stringWithoutAccents);


### PR DESCRIPTION
In the project of my company we have some files for which blame fails and is unable to retrieve the author of some/all lines. For these files the sonar-scm-activity-plugin throws a NullPointerException in the method normalizeString(String) in the class Blame.
This fix simply adds a null-check in normalizeString(String) and returns an empty String in this case.